### PR TITLE
Got rid of deprecation warnings on symfony 2.8.

### DIFF
--- a/Form/Type/MarkdownType.php
+++ b/Form/Type/MarkdownType.php
@@ -23,6 +23,12 @@ class MarkdownType extends AbstractType
     /**
      * {@inheritdoc}
      */
+    public function configureOptions(\Symfony\Component\OptionsResolver\OptionsResolver $resolver) {
+        $this->setDefaultOptions($resolver);
+    }
+    /**
+     * {@inheritdoc}
+     */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
         $resolver->setDefaults(array(
@@ -37,11 +43,18 @@ class MarkdownType extends AbstractType
 
     public function getParent()
     {
-        return 'textarea';
+        if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            return 'textarea';
+        } else {
+            return \Symfony\Component\Form\Extension\Core\Type\TextareaType::class;
+        }
     }
 
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'markdown';
+    }
+    public function getName() {
+        return $this->getBlockPrefix();
     }
 }


### PR DESCRIPTION
Gets rid of:

The method FormTypeInterface::getName() was deprecated, you should now implement FormTypeInterface::getBlockPrefix() instead.

The FormTypeInterface::setDefaultOptions() method is deprecated since version 2.7 and will be removed in 3.0. Use configureOptions() instead. This method will be added to the FormTypeInterface with Symfony 3.0.

Accessing type "textarea" by its string name is deprecated since version 2.8 and will be removed in 3.0. Use the fully-qualified type class name "Symfony\Component\Form\Extension\Core\Type\TextareaType" instead.
